### PR TITLE
Shillelagh spell fix: Auto-select player's weapon if not specified

### DIFF
--- a/alfa2_acr.hak/acr_s0_shillelagh.NSS
+++ b/alfa2_acr.hak/acr_s0_shillelagh.NSS
@@ -59,8 +59,10 @@ void main()
     nCurrentEnhancement = IPGetWeaponEnhancementBonus(oTarget, ITEM_PROPERTY_ENHANCEMENT_BONUS);
 
     // Is target not a club/quarterstaff OR is target not made of wood OR
-    // is the target have an enhancement bonus > 0
+    // is the target have an enhancement bonus > 0 OR
+    // not a valid object
     if (
+        oTarget == OBJECT_INVALID ||
         (nBaseItemType != BASE_ITEM_CLUB && nBaseItemType != BASE_ITEM_QUARTERSTAFF) ||
         (nMaterialType != GMATERIAL_NONSPECIFIC && nMaterialType != GMATERIAL_WOOD_DUSKWOOD) ||
         nCurrentEnhancement > 0

--- a/alfa2_acr.hak/acr_s0_shillelagh.NSS
+++ b/alfa2_acr.hak/acr_s0_shillelagh.NSS
@@ -51,8 +51,9 @@ void main()
         return;
     }
 
-    oTarget = GetSpellTargetObject();
     oCaster = OBJECT_SELF;
+    oTarget = IPGetTargetedOrEquippedMeleeWeapon();
+
     nBaseItemType = GetBaseItemType(oTarget);
     nMaterialType = GetItemBaseMaterialType(oTarget);
     nCurrentEnhancement = IPGetWeaponEnhancementBonus(oTarget, ITEM_PROPERTY_ENHANCEMENT_BONUS);

--- a/alfa2_acr.hak/acr_s0_shillelagh.NSS
+++ b/alfa2_acr.hak/acr_s0_shillelagh.NSS
@@ -39,6 +39,25 @@ void verify_owner(object oCaster, object oWeapon, itemproperty ipBludgeon, itemp
 }
 
 
+int isClubOrQuarterstaff(int nBaseItemType)
+{
+    return (
+        nBaseItemType == BASE_ITEM_CLUB ||
+        nBaseItemType == BASE_ITEM_QUARTERSTAFF
+    );
+}
+
+
+int isWooden(int nMaterialType)
+{
+    return (
+        nMaterialType == GMATERIAL_NONSPECIFIC ||
+        nMaterialType == GMATERIAL_WOOD_DUSKWOOD ||
+        nMaterialType == GMATERIAL_WOOD_DARKWOOD
+    );
+}
+
+
 void main()
 {
     object oCaster, oTarget;
@@ -56,15 +75,20 @@ void main()
 
     nBaseItemType = GetBaseItemType(oTarget);
     nMaterialType = GetItemBaseMaterialType(oTarget);
-    nCurrentEnhancement = IPGetWeaponEnhancementBonus(oTarget, ITEM_PROPERTY_ENHANCEMENT_BONUS);
 
-    // Is target not a club/quarterstaff OR is target not made of wood OR
+    // Enhancement check errors out for OBJECT_INVALID
+    if (oTarget != OBJECT_INVALID) {
+        nCurrentEnhancement = IPGetWeaponEnhancementBonus(oTarget, ITEM_PROPERTY_ENHANCEMENT_BONUS);
+    }
+
+    // Is target not a club/quarterstaff OR
+    // is target not made of wood OR
     // is the target have an enhancement bonus > 0 OR
-    // not a valid object
+    // is not a valid object
     if (
         oTarget == OBJECT_INVALID ||
-        (nBaseItemType != BASE_ITEM_CLUB && nBaseItemType != BASE_ITEM_QUARTERSTAFF) ||
-        (nMaterialType != GMATERIAL_NONSPECIFIC && nMaterialType != GMATERIAL_WOOD_DUSKWOOD) ||
+        !isClubOrQuarterstaff(nBaseItemType) ||
+        !isWooden(nMaterialType) ||
         nCurrentEnhancement > 0
     ) {
         SendMessageToPC(oCaster, "Spell target must be a club or quarterstaff that is wooden and non-magical.");

--- a/alfa2_acr.hak/acr_s0_shillelagh.NSS
+++ b/alfa2_acr.hak/acr_s0_shillelagh.NSS
@@ -61,7 +61,7 @@ int isWooden(int nMaterialType)
 void main()
 {
     object oCaster, oTarget;
-    int nCasterLevel, nBaseItemType, nMaterialType, nCurrentEnhancement;
+    int nCasterLevel, nBaseItemType, nMaterialType = 0, nCurrentEnhancement = 0;
     float fDuration;
     itemproperty ipBludgeon, ipEnhancement;
 
@@ -74,11 +74,11 @@ void main()
     oTarget = IPGetTargetedOrEquippedMeleeWeapon();
 
     nBaseItemType = GetBaseItemType(oTarget);
-    nMaterialType = GetItemBaseMaterialType(oTarget);
 
-    // Enhancement check errors out for OBJECT_INVALID
-    if (oTarget != OBJECT_INVALID) {
+    // Only check for weapons
+    if (isClubOrQuarterstaff(nBaseItemType)) {
         nCurrentEnhancement = IPGetWeaponEnhancementBonus(oTarget, ITEM_PROPERTY_ENHANCEMENT_BONUS);
+        nMaterialType = GetItemBaseMaterialType(oTarget);
     }
 
     // Is target not a club/quarterstaff OR

--- a/tlk/alfa.tls
+++ b/tlk/alfa.tls
@@ -4893,8 +4893,7 @@ In addition to providing illumination, the flames can be hurled or used to touch
 
 This spell does not function underwater. 
 <1333><16778549>:Shillelagh
-<1334><16778550>:<b>Shillelagh</b>
-Transmutation
+<1334><16778550>:Transmutation
 Level: Drd 1
 Components: V, S, DF
 Casting Time: 1 standard action


### PR DESCRIPTION
Minor fixes to spell: pick weapon if there isn't one selected and update tlk